### PR TITLE
Add an explicit dependency on json 1.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ gemspec
 
 source 'http://rubygems.org'
 
-gem 'simplecov'
+group :test do
+  gem 'simplecov'
+  gem 'json', '~> 1.7.7'
+end


### PR DESCRIPTION
On OS X I get the following message when running the specs (caused by 
SimpleCov):

```
You are using an old or stdlib version of json gem
```

   Please upgrade to the recent version by adding this to your Gemfile:

```
  gem 'json', '~> 1.7.7'
```
